### PR TITLE
Fix: improve sql creation statement to accept sql reserved words as columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.egg-info/
+build/
+dist/

--- a/pandas2redshift/pandas2redshift.py
+++ b/pandas2redshift/pandas2redshift.py
@@ -160,7 +160,7 @@ def create_table(
         schema (str): The schema of the table.
         data_types (Dict): A dictionary of column names and their data types.
     """
-    column_definitions = ",\n".join(f"{key} {val}" for key, val in data_types.items())
+    column_definitions = ",\n".join(f'"{key}" {val}' for key, val in data_types.items())
     CREATE_TABLE_QUERY = f"""
         CREATE TABLE {schema}.{table_name} (
             {column_definitions}


### PR DESCRIPTION
As title says, "begin", "end"... sql reserved words were not accepted as column names. I also add a gitignore in order to the repo be codespace-friendly, as those folders are automaticaly created.